### PR TITLE
UX/UI sidebar of Extension Manager: swap buttons order to become  [Help Options]

### DIFF
--- a/administrator/components/com_installer/views/discover/view.html.php
+++ b/administrator/components/com_installer/views/discover/view.html.php
@@ -52,7 +52,6 @@ class InstallerViewDiscover extends InstallerViewDefault
 		JToolbarHelper::custom('discover.install', 'upload', 'upload', 'JTOOLBAR_INSTALL', true, false);
 		JToolbarHelper::custom('discover.refresh', 'refresh', 'refresh', 'COM_INSTALLER_TOOLBAR_DISCOVER', false, false);
 		JToolbarHelper::divider();
-		JToolbarHelper::help('JHELP_EXTENSIONS_EXTENSION_MANAGER_DISCOVER');
 
 		JHtmlSidebar::setAction('index.php?option=com_installer&view=discover');
 
@@ -96,5 +95,6 @@ class InstallerViewDiscover extends InstallerViewDefault
 		);
 
 		parent::addToolbar();
+		JToolbarHelper::help('JHELP_EXTENSIONS_EXTENSION_MANAGER_DISCOVER');
 	}
 }

--- a/administrator/components/com_installer/views/manage/view.html.php
+++ b/administrator/components/com_installer/views/manage/view.html.php
@@ -84,8 +84,6 @@ class InstallerViewManage extends InstallerViewDefault
 			JToolbarHelper::divider();
 		}
 
-		JToolbarHelper::help('JHELP_EXTENSIONS_EXTENSION_MANAGER_MANAGE');
-
 		JHtmlSidebar::setAction('index.php?option=com_installer&view=manage');
 
 		JHtmlSidebar::addFilter(
@@ -141,5 +139,6 @@ class InstallerViewManage extends InstallerViewDefault
 		);
 
 		parent::addToolbar();
+		JToolbarHelper::help('JHELP_EXTENSIONS_EXTENSION_MANAGER_MANAGE');
 	}
 }

--- a/administrator/components/com_installer/views/update/view.html.php
+++ b/administrator/components/com_installer/views/update/view.html.php
@@ -83,7 +83,6 @@ class InstallerViewUpdate extends InstallerViewDefault
 		JToolbarHelper::custom('update.purge', 'purge', 'purge', 'COM_INSTALLER_TOOLBAR_PURGE', false, false);
 		JToolbarHelper::divider();
 
-		JToolbarHelper::help('JHELP_EXTENSIONS_EXTENSION_MANAGER_UPDATE');
 		JHtmlSidebar::setAction('index.php?option=com_installer&view=manage');
 
 		JHtmlSidebar::addFilter(
@@ -111,5 +110,6 @@ class InstallerViewUpdate extends InstallerViewDefault
 			)
 		);
 		parent::addToolbar();
+		JToolbarHelper::help('JHELP_EXTENSIONS_EXTENSION_MANAGER_UPDATE');
 	}
 }

--- a/administrator/components/com_installer/views/updatesites/view.html.php
+++ b/administrator/components/com_installer/views/updatesites/view.html.php
@@ -86,8 +86,6 @@ class InstallerViewUpdatesites extends InstallerViewDefault
 			JToolbarHelper::divider();
 		}
 
-		JToolbarHelper::help('JHELP_EXTENSIONS_EXTENSION_MANAGER_UPDATESITES');
-
 		JHtmlSidebar::setAction('index.php?option=com_installer&view=updatesites');
 
 		JHtmlSidebar::addFilter(
@@ -115,5 +113,6 @@ class InstallerViewUpdatesites extends InstallerViewDefault
 		);
 
 		parent::addToolbar();
+		JToolbarHelper::help('JHELP_EXTENSIONS_EXTENSION_MANAGER_UPDATESITES');
 	}
 }


### PR DESCRIPTION
Long standing issue, description at https://github.com/joomla/joomla-cms/issues/5921 , com_installer views are producing inconsistent UI / buttons ordering.
